### PR TITLE
Fix: readOne, update 시 boardId와 각 각의 Id값이 모두 존재할 때만 조회하기

### DIFF
--- a/src/main/java/com/example/travelers/repos/ReceiverRequestsRepository.java
+++ b/src/main/java/com/example/travelers/repos/ReceiverRequestsRepository.java
@@ -1,10 +1,11 @@
 package com.example.travelers.repos;
 
 import com.example.travelers.entity.ReceiverRequestsEntity;
+import com.example.travelers.entity.SenderRequestsEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface ReceiverRequestsRepository extends JpaRepository<ReceiverRequestsEntity, Long> {
-    
+    Optional<ReceiverRequestsEntity> findByBoardIdAndId(Long boardId, Long id);
 }

--- a/src/main/java/com/example/travelers/repos/SenderRequestsRepository.java
+++ b/src/main/java/com/example/travelers/repos/SenderRequestsRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 @Repository
 public interface SenderRequestsRepository extends JpaRepository<SenderRequestsEntity, Long> {
+    Optional<SenderRequestsEntity> findByBoardIdAndId(Long boardId, Long id);
     List<SenderRequestsEntity> findAllBySenderId(Long id);
     List<SenderRequestsEntity> findAllByBoardId(Long boardId);
     Optional<SenderRequestsEntity> findByBoardIdAndSenderId(Long boardId, Long id);

--- a/src/main/java/com/example/travelers/service/ReceiverRequestsService.java
+++ b/src/main/java/com/example/travelers/service/ReceiverRequestsService.java
@@ -56,9 +56,11 @@ public class ReceiverRequestsService {
         if (boardsEntity.isEmpty())
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "수정할 게시글이 존재하지 않습니다.");
 
-        // id에 해당하는 동행 요청이 존재하지 않을 경우 예외 처리
-        Optional<ReceiverRequestsEntity> receiverRequestsEntity
-                = receiverRequestsRepository.findById(id);
+        // boardId, SenderId가 모두 존재할 때만 조회
+        Optional<ReceiverRequestsEntity> receiverRequestsEntity = receiverRequestsRepository.findByBoardIdAndId(boardId, id);
+        if (receiverRequestsEntity.isEmpty())
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "수정할 동행 요청이 존재하지 않습니다");
+
         // Optional에서 Entity 받아오기
         ReceiverRequestsEntity receiver = receiverRequestsEntity.get();
 

--- a/src/main/java/com/example/travelers/service/SenderRequestsService.java
+++ b/src/main/java/com/example/travelers/service/SenderRequestsService.java
@@ -70,8 +70,9 @@ public class SenderRequestsService {
         if (!boardsRepository.existsById(boardId))
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "조회할 게시글이 존재하지 않습니다.");
 
-        // id에 해당하는 동행 요청이 존재하지 않을 경우 예외 처리
-        Optional<SenderRequestsEntity> senderRequestsEntity = senderRequestsRepository.findById(id);
+
+        // boardId, SenderId가 모두 존재할 때만 조회
+        Optional<SenderRequestsEntity> senderRequestsEntity = senderRequestsRepository.findByBoardIdAndId(boardId, id);
         if (senderRequestsEntity.isEmpty())
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "조회할 동행 요청이 존재하지 않습니다");
 
@@ -104,8 +105,8 @@ public class SenderRequestsService {
         if (!boardsRepository.existsById(boardId))
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "수정할 게시글이 존재하지 않습니다.");
 
-        // id에 해당하는 동행 요청이 존재하지 않을 경우 예외 처리
-        Optional<SenderRequestsEntity> senderRequestsEntity = senderRequestsRepository.findById(id);
+        // boardId, SenderId가 모두 존재할 때만 조회
+        Optional<SenderRequestsEntity> senderRequestsEntity = senderRequestsRepository.findByBoardIdAndId(boardId, id);
         if (senderRequestsEntity.isEmpty())
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "수정할 동행 요청이 존재하지 않습니다");
 


### PR DESCRIPTION
- SenderRequestsRepository
- SenderRequestsService
- ReceiverRequestsRepository
- ReceiverRequestsService